### PR TITLE
chore: Install mapeo-settings-builder only once globally instead of differently for each package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # mapeo-default-config
 
 This is the default config (categories, icons and questions) used by Mapeo for data collection. Users can override this with their own config with custom categories, icons and questions.
+
+
+## Prerequisites
+
+Please install the latest version of mapeo-settings-builder.
+
+```
+npm install -g mapeo-settings-builder
+```
+
+For more information on how to use this package, and for troubleshooting,
+including how to install Node.js and npm, please see the [Mapeo User
+Guide](https://docs.mapeo.app/customization/preparing-mapeo-configuration).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Mapeo default config (categories, icons, questions)",
   "dependencies": {},
   "devDependencies": {
-    "mapeo-settings-builder": "^3.1.1",
     "mkdirp": "^1.0.4",
     "rimraf": "^3.0.2"
   },


### PR DESCRIPTION
For users going forward, I think we want to recommend that they use the latest version of the mapeo-settings-builder. This is because this is the version that is compatible with the released stable versions of Mapeo Desktop and Mobile, and has all the latest and greatest checks & validations for the configuration files.

By requiring it to be installed as a global package, it makes it easier for folks to ensure they have the latest version of mapeo-settings-builder installed, as well as faster to author configurations (mapeo-settings-builder takes a while to install because it needs to install and compile chromium). There is a cognitive load to understand the difference between a 'local' and 'global' package; understanding command line is already a lot to ask of users.

It's possible that older versions of mapeo-settings-builder will be required for partners relying upon older versions of Mapeo Desktop as we have introduced breaking changes since 1.x and 2.x. In those cases, they should already have a package.json installed with the relevant version of mapeo-settings-builder. 
