### PR TITLE
chore: remove unused dataset_id metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,3 +1,1 @@
-{
-  "dataset_id": "mapeo-jungle"
-}
+{}


### PR DESCRIPTION
This is a legacy from older versions.