### PR TITLE
chore: update translation field.options to use {label, value}

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -21,27 +21,27 @@
   },
   "fields.building-type.options.Church": {
     "description": "Label for option 'Church' for field 'building-type'",
-    "message": "Church"
+    "message": {"label": "Church", "value": "Church"}
   },
   "fields.building-type.options.Homestead": {
     "description": "Label for option 'Homestead' for field 'building-type'",
-    "message": "Homestead"
+    "message": {"label": "Homestead", "value": "Homestead"}
   },
   "fields.building-type.options.Hospital": {
     "description": "Label for option 'Hospital' for field 'building-type'",
-    "message": "Hospital"
+    "message": {"label": "Hospital", "value": "Hospital"}
   },
   "fields.building-type.options.Other": {
     "description": "Label for option 'Other' for field 'building-type'",
-    "message": "Other"
+    "message": {"label":"Other", "value": "Other"}
   },
   "fields.building-type.options.School": {
     "description": "Label for option 'School' for field 'building-type'",
-    "message": "School"
+    "message": {"label": "School", "value": "School"}
   },
   "fields.building-type.options.Shop": {
     "description": "Label for option 'Shop' for field 'building-type'",
-    "message": "Shop"
+    "message": {"label": "Shop", "value": "Shop"}
   },
   "fields.building-type.placeholder": {
     "description": "An example to guide the user for field 'building-type'",

--- a/messages/es.json
+++ b/messages/es.json
@@ -13,27 +13,27 @@
   },
   "fields.building-type.options.Church": {
     "description": "Label for option 'Church' for field 'building-type'",
-    "message": "Iglesia"
+    "message": {"label": "Iglesia", "value": "Iglesia"}
   },
   "fields.building-type.options.Homestead": {
     "description": "Label for option 'Homestead' for field 'building-type'",
-    "message": "Caserío"
+    "message": {"label":"Caserío", "value": "Caserio"}
   },
   "fields.building-type.options.Hospital": {
     "description": "Label for option 'Hospital' for field 'building-type'",
-    "message": "Hospital"
+    "message": {"label": "Hospital", "value": "Hospital"}
   },
   "fields.building-type.options.Other": {
     "description": "Label for option 'Other' for field 'building-type'",
-    "message": "Otro"
+    "message": {"label": "Otro", "value": "Otro"}
   },
   "fields.building-type.options.School": {
     "description": "Label for option 'School' for field 'building-type'",
-    "message": "Escuela"
+    "message": {"label": "Escuela", "value": "Escuela"}
   },
   "fields.building-type.options.Shop": {
     "description": "Label for option 'Shop' for field 'building-type'",
-    "message": "Tienda"
+    "message": {"label": "Tienda", "value": "Tienda"}
   },
   "fields.building-type.placeholder": {
     "description": "An example to guide the user for field 'building-type'",

--- a/messages/it.json
+++ b/messages/it.json
@@ -13,23 +13,23 @@
   },
   "fields.building-type.options.Church": {
     "description": "Label for option 'Church' for field 'building-type'",
-    "message": "Chiesa"
+    "message": {"label": "Chiesa", "value":"Chiesa"}
   },
   "fields.building-type.options.Hospital": {
     "description": "Label for option 'Hospital' for field 'building-type'",
-    "message": "Ospedale"
+    "message": {"label": "Ospedale", "value": "Ospedale"}
   },
   "fields.building-type.options.Other": {
     "description": "Label for option 'Other' for field 'building-type'",
-    "message": "Altro"
+    "message": {"label": "Altro", "value": "Altro"}
   },
   "fields.building-type.options.School": {
     "description": "Label for option 'School' for field 'building-type'",
-    "message": "Scuola"
+    "message": {"label": "Scuola", "value": "Scuola"}
   },
   "fields.building-type.options.Shop": {
     "description": "Label for option 'Shop' for field 'building-type'",
-    "message": "Negozio"
+    "message": {"label": "Negozio", "value": "Negozio"}
   },
   "fields.building-type.placeholder": {
     "description": "An example to guide the user for field 'building-type'",

--- a/messages/sw.json
+++ b/messages/sw.json
@@ -13,27 +13,27 @@
   },
   "fields.building-type.options.Church": {
     "description": "Label for option 'Church' for field 'building-type'",
-    "message": "Kanisa"
+    "message": {"label": "Kanisa", "value": "Kanisa"}
   },
   "fields.building-type.options.Homestead": {
     "description": "Label for option 'Homestead' for field 'building-type'",
-    "message": "Nyumba iliyozungukwa na shamba"
+    "message": {"label": "Nyumba iliyozungukwa na shamba", "value": "Nyumba iliyozungukwa na shamba"}
   },
   "fields.building-type.options.Hospital": {
     "description": "Label for option 'Hospital' for field 'building-type'",
-    "message": "Hospitali"
+    "message": {"label": "Hospitali", "value": "Hospitali"}
   },
   "fields.building-type.options.Other": {
     "description": "Label for option 'Other' for field 'building-type'",
-    "message": "Nyingine"
+    "message": {"label": "Nyingine", "value": "Nyingine"}
   },
   "fields.building-type.options.School": {
     "description": "Label for option 'School' for field 'building-type'",
-    "message": "Shule"
+    "message": {"label": "Shule", "value": "Shule"}
   },
   "fields.building-type.options.Shop": {
     "description": "Label for option 'Shop' for field 'building-type'",
-    "message": "Duka"
+    "message": {"label": "Duka", "value": "Duka"}
   },
   "fields.building-type.placeholder": {
     "description": "An example to guide the user for field 'building-type'",


### PR DESCRIPTION
when we fix invalid fields (see https://github.com/digidem/mapeo-default-config/pull/40/files) we didn't also updated translations so that they use the updated schema for fields (specifically using `{label, value}[]` for options instead of only `label[]`