### PR TITLE
fix: `.mapeoconfig` ->  `.comapeocat` on `build:dist` and on `main`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "mkdirp build && mapeo-settings build -l 'en' -o build/mapeo-default-config-v${npm_package_version}.comapeocat",
-    "build:dist": "mapeo-settings build -l 'en' -o dist/mapeo-default-config.mapeoconfig",
+    "build:dist": "mapeo-settings build -l 'en' -o dist/mapeo-default-config.comapeocat",
     "extract-messages": "mkdirp messages && mapeo-settings extract-messages -o messages/en.json",
     "prepack": "rimraf dist && mkdirp dist && npm run -s build:dist",
     "test": "mapeo-settings lint"
@@ -19,7 +19,7 @@
   "files": [
     "dist"
   ],
-  "main": "dist/mapeo-default-config.mapeoconfig",
+  "main": "dist/mapeo-default-config.comapeocat",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/digidem/mapeo-default-config.git"


### PR DESCRIPTION
I missed updating the extension on a couple of more places on https://github.com/digidem/mapeo-default-config/pull/63, this PR fixes that